### PR TITLE
Improved final filtering

### DIFF
--- a/site/utils/getIntersectionAreas/getIntersectionAreas.ts
+++ b/site/utils/getIntersectionAreas/getIntersectionAreas.ts
@@ -96,7 +96,7 @@ export default (shapes: IntersectionCircle[]) => {
     areas: areas
       .filter(area =>
         (area instanceof Circle && area.arcs.length == 0) || // Only stand-alone circles...
-        area.area > 0 // ... and interior regions
+        (area instanceof Area && area.area > 0) // ... and interior regions
       )
       .sort((a, b) => b.area - a.area),
     circles: circles,

--- a/site/utils/getIntersectionAreas/getIntersectionAreas.ts
+++ b/site/utils/getIntersectionAreas/getIntersectionAreas.ts
@@ -94,7 +94,10 @@ export default (shapes: IntersectionCircle[]) => {
 
   return {
     areas: areas
-      .filter((area) => !area.arcs.length || !area.arcs.every((arc) => !arc.isConvex(area.arcs)))
+      .filter(area =>
+        (area instanceof Circle && area.arcs.length == 0) || // Only stand-alone circles...
+        area.area > 0 // ... and interior regions
+      )
       .sort((a, b) => b.area - a.area),
     circles: circles,
     vectors: vectors,


### PR DESCRIPTION
Hey, Harrison,

I've been playing around with your code, and I found what I consider to be a bug: it doesn't allow for "negative" regions. If you arrange three circles so they all touch each other but don't have a common region between all three of them, there is a "triangular" region in the middle which doesn't belong to any of them, but which, I believe, should be fillable. This is what I call a negative region (because it's a negative space).

I know your final filter was meant to exclude exterior regions, but it had the side effect of also excluding these negative spaces. I found that I could exploit a quirk in the code to filter out exterior regions without excluding these negative spaces: instead of checking for all-not-convex arcs, the way you did it, I'm simply checking for positive surface areas. As far as I could test, the algorithm somehow ends up with negative values for the surface area only for exterior regions, whereas interior negative regions have positive values.

I also did one more thing: I excluded the circles which are already split into areas from the final result set – they were doing nothing, because they always ended up being rendered below all areas which already covered them 100%.

Please let me know if I got any of this wrong.